### PR TITLE
Add rake task to sweep out expired job posts.

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -2,7 +2,7 @@ require File.join(Rails.root, 'lib', 'slug')
 class Job < ActiveRecord::Base
   is_sluggable :title
 
-  has_many :job_views
+  has_many :job_views, :dependent => :destroy
   has_many :viewers, :through => :job_views
   belongs_to :user
 
@@ -13,6 +13,10 @@ class Job < ActiveRecord::Base
 
   scope :published, lambda {
     where("jobs.published_at IS NOT NULL AND jobs.published_at <= ?", Time.zone.now)
+  }
+
+  scope :stale, lambda {
+    where("created_at < ?", 60.days.ago)
   }
 
   def notify_if_published

--- a/app/models/job_view.rb
+++ b/app/models/job_view.rb
@@ -1,4 +1,4 @@
 class JobView < ActiveRecord::Base
-  belongs_to :job
+  belongs_to :job, :dependent => :destroy
   belongs_to :viewer
 end

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -1,0 +1,6 @@
+namespace :admin do
+  desc 'Remove stale jobs (and dependents)'
+  task :sweep_jobs => :environment do
+    Job.stale.destroy_all
+  end  
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -1,4 +1,14 @@
 require 'spec_helper'
 
 describe Job do
+  context "#stale" do
+    it "scopes results to jobs older than 60 days" do
+      @stale_job = FactoryGirl.create(:job, :created_at => 61.days.ago)
+      @fresh_job = FactoryGirl.create(:job, :created_at => 59.day.ago)
+      
+      results = Job.stale
+      results.should include(@stale_job)
+      results.should_not include(@fresh_job)
+    end
+  end
 end


### PR DESCRIPTION
You'll need to add `rake admin:sweep_jobs` to the Heroku scheduler - preferably to run daily.
