### PR TITLE
Switch app server to unicorn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # Gems host
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 ruby '1.9.3'
 
 gem 'rails', '3.2.19'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'slugged'
 gem 'delayed_job'
 
 gem 'json_pure'
-gem 'thin'
+gem 'unicorn'
 gem 'newrelic_rpm'
 gem 'instrumental_agent'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,6 @@ GEM
       capybara (>= 1.1.2)
       cucumber (>= 1.1.8)
       nokogiri (>= 1.5.0)
-    daemons (1.1.9)
     dalli (2.6.0)
     database_cleaner (0.9.1)
     deadweight (0.2.2)
@@ -72,7 +71,6 @@ GEM
       warden (~> 1.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    eventmachine (1.0.0)
     excon (0.16.10)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -113,6 +111,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     json_pure (1.7.6)
+    kgio (2.10.0)
     launchy (2.1.2)
       addressable (~> 2.3)
     libwebsocket (0.1.7.1)
@@ -165,6 +164,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
+    raindrops (0.17.0)
     rake (10.3.2)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -219,10 +219,6 @@ GEM
       rest-client (>= 1.4.0, < 1.7.0)
       sequel (~> 3.20.0)
       sinatra (~> 1.0.0)
-    thin (1.5.0)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.19.1)
     tilt (1.4.1)
     treetop (1.4.15)
@@ -232,6 +228,9 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    unicorn (5.1.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     uuid (2.3.6)
       macaddr (~> 1.0)
     warden (1.2.1)
@@ -283,6 +282,6 @@ DEPENDENCIES
   spork
   stringex
   taps
-  thin
   uglifier
+  unicorn
   will_paginate (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.19)
       actionpack (= 3.2.19)

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,22 @@
+worker_processes 4
+timeout 15
+preload_app true
+
+before_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
This pull request switches the app server to Unicorn ( which has a slightly less hairy build process than EventMachine, and is better supported than Thin ), and switches the gem source to use the https RubyGems endpoint.