### PR TITLE
Change text on charity support

### DIFF
--- a/public/holiday-social-2016/index.html
+++ b/public/holiday-social-2016/index.html
@@ -455,10 +455,9 @@
 
                   <!-- Item -->
                   <li>
-                    <h3>Bring a can?</h3>
+                    <h3>Help other folks have a good holiday?</h3>
                     <p class="icon-1 icon-1-6">
-                      As much as we love giving back by bringing all of this amazing talent together...we also know that this is an incredible opportunity to give back to those less fortunate as well. So, on your way to the event, grab a can or two and we will donate them to the less fortunate.
-                    </p>
+                      As much as we love giving back by bringing all of this amazing talent together...we also know that this is an incredible opportunity to give back to those less fortunate as well. This year we'll be matching donations given at the event to <a href="https://secondhelpings.org/">Second Helpings</a>, an Indianapolis based charity that repurposes unused restaurant food, delivers meals to those in need, and provide culinary training to disadvantaged adults. </p>
                   </li>
                   <!-- /Item -->
 


### PR DESCRIPTION
This PR changes the text on the charitable giving for Holiday Social 2016 to the intended charity, [Second Helpings](https://secondhelpings.org/). 