### PR TITLE
Fix Calendar feed link

### DIFF
--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -34,5 +34,5 @@
     %p
       = link_to 'Month View', '/calendar'
       |
-      = link_to 'Subscribe to the Events Feed', 'https://www.google.com/calendar/feeds/ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com/public/basic'
+      = link_to 'Subscribe to the Events Feed', 'webcal://calendar.google.com/calendar/ical/ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com/public/basic.ics'
     <iframe src="http://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23DDDDDD&amp;src=ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com&amp;color=%23AB8B00&amp;ctz=America%2FNew_York" style="border-width:0 " width="800" height="400" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This addresses issue #25 - the Google RSS feed link has been deprecated. In order to provide a calendar subscription link, I've changed the destination to the ICS file for the calendar, and used the `webcal` protocol such that calendar applications should regularly poll for updates.