### PR TITLE
Add photo galleries of past events to old event pages

### DIFF
--- a/public/holiday-social-2012/index.html
+++ b/public/holiday-social-2012/index.html
@@ -88,11 +88,14 @@
             <h1>Holiday Social 2012</h1>
 
             <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
-              <span class="bold">What is the best way to celebrate the holidays? Music, food, drink, and friends, old and new!</a></p>
+              <span class="bold">What is the best way to celebrate the holidays? Music, food, drink, and friends, old and new!</span>
+            </p>
             <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
               Please join us &mdash; a bunch of programmers, nerds, geeks, <strong>hackers</strong> &mdash; to celebrate the season with food, drink, music, and friends both old and new. <strong>December 15th, 7PM, at The Speak Easy</strong> in Broad Ripple, you'll see Pythonistas touching glasses with Java guys, Rubyists joking with the .NET-ers, COBOL gentlemen adjusting their bowler hats &mdash; everyone is more than welcome. The best part? It is <em>completely</em> <strong>free</strong>.
             </p>
-
+            <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
+              <strong>Update!</strong> You can't join us because this event is over. Like, <em>WAY</em> over. And unfortunately, there is no photographic evidence of the 2012 event. But you CAN travel back even further in time and see <a href="https://thirdshift.smugmug.com/Other/Other-1/Indy-Hackers-Holiday-2011/n-qM6NZ/">pictures from the 2011 event</a>, as captured by official Holiday Social documentarian, <a href="https://twitter.com/thirdshift">@thirdshift</a>.
+            </p>
             <a href="http://indyhackersholidaysocial2012.eventbrite.com/" class="button-black clear-fix">
               <span class="click-here"></span>
               Get Your Free Ticket

--- a/public/holiday-social-2012/style/base.css
+++ b/public/holiday-social-2012/style/base.css
@@ -28,8 +28,8 @@ time,mark,audio,video
 /*  Base styles																  */
 /******************************************************************************/
 
-html { 
-  background: url(/assets/speakeasy-bg.jpg) no-repeat center center fixed; 
+html {
+  background: url(/assets/speakeasy-bg.jpg) no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;
@@ -251,6 +251,13 @@ ul.list-1 li h5,
 input,textarea,label
 {
 	color:#000000;
+}
+
+.subtitle-paragraph a, .subtitle-paragraph a:hover {
+	color: black;
+	font-size: inherit;
+	font-family: inherit;
+	text-decoration: underline;
 }
 
 /******************************************************************************/
@@ -1371,4 +1378,3 @@ form.simple_form .input input.button {
   width: 72px;
   height: 72px;
 }
-

--- a/public/holiday-social-2013/index.html
+++ b/public/holiday-social-2013/index.html
@@ -92,6 +92,9 @@
             <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
             Please join us &mdash; a bunch of programmers, nerds, geeks, <strong>hackers</strong> &mdash; to celebrate the year with food, drink, and friends both old and new. <strong>December 7th, 7PM, at The Speak Easy</strong> in Broad Ripple, we will have the <em>third</em> annual Indy Hackers' Holiday Social. We welcome everyone -- Pythonistas, Javanese, COBOLians, Scalanites, PHPers, Rubyists, .NET nuts, Perlsians.... We might even have some hardcore functional programming zealots giving in to mutable state for a few hours. The best part? It is <em>completely</em> <strong>free</strong>.
             </p>
+            <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
+              <strong>Update!</strong> You can't join us because this event is over. Like, <em>WAY</em> over. You can relive the excitement by checking out the <a href="http://thirdshift.smugmug.com/Indy-Hackers-Holiday-Social/">pictures from the event</a>, as captured by official Holiday Social documentarian, <a href="https://twitter.com/thirdshift">@thirdshift</a>.
+            </p>
 
             <a href="http://indyhackersholidaysocial2013.eventbrite.com/" class="button-black clear-fix">
               <span class="click-here"></span>

--- a/public/holiday-social-2013/style/base.css
+++ b/public/holiday-social-2013/style/base.css
@@ -28,8 +28,8 @@ time,mark,audio,video
 /*  Base styles																  */
 /******************************************************************************/
 
-html { 
-  background: url(/assets/speakeasy-bg.jpg) no-repeat center center fixed; 
+html {
+  background: url(/assets/speakeasy-bg.jpg) no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;
@@ -251,6 +251,13 @@ ul.list-1 li h5,
 input,textarea,label
 {
 	color:#000000;
+}
+
+.subtitle-paragraph a, .subtitle-paragraph a:hover {
+	color: black;
+	font-size: inherit;
+	font-family: inherit;
+	text-decoration: underline;
 }
 
 /******************************************************************************/
@@ -1371,4 +1378,3 @@ form.simple_form .input input.button {
   width: 72px;
   height: 72px;
 }
-

--- a/public/holiday-social-2014/index.html
+++ b/public/holiday-social-2014/index.html
@@ -92,6 +92,10 @@
             <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
             Please join us &mdash; a bunch of programmers, nerds, geeks, <strong>hackers</strong> &mdash; to celebrate the year with food, drink, and friends both old and new. <strong>Saturday, December 6th, 7PM, at The Speak Easy</strong> in Indianapolis, we will have the <em>fourth</em> annual Indy Hackers' Holiday Social. We welcome everyone -- Pythonistas, Javanese, COBOLians, Scalanites, PHPers, Rubyists, .NET nuts, Perlsians.... We might even have some hardcore functional programming zealots giving in to mutable state for a few hours. The best part? It is <em>completely</em> <strong>free</strong>.
             </p>
+            <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
+              <strong>Update!</strong> You can't join us because this event is over. Like, <em>WAY</em> over. You can relive the excitement by checking out the <a href="http://thirdshift.smugmug.com/2014-Indy-Hackers-Holiday-Soci/">pictures from the event</a>, as captured by official Holiday Social documentarian, <a href="https://twitter.com/thirdshift">@thirdshift</a>.
+            </p>
+
 
             <a href="https://www.eventbrite.com/e/indy-hackers-holiday-social-2014-tickets-13850221385" class="button-black clear-fix">
               <span class="click-here"></span>

--- a/public/holiday-social-2014/style/base.css
+++ b/public/holiday-social-2014/style/base.css
@@ -253,6 +253,13 @@ input,textarea,label
 	color:#000000;
 }
 
+.subtitle-paragraph a, .subtitle-paragraph a:hover {
+	color: black;
+	font-size: inherit;
+	font-family: inherit;
+	text-decoration: underline;
+}
+
 /******************************************************************************/
 /*  Background colors														  */
 /******************************************************************************/

--- a/public/holiday-social-2015/index.html
+++ b/public/holiday-social-2015/index.html
@@ -102,6 +102,10 @@
             <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
               Please join us &mdash; a bunch of programmers, nerds, geeks, <strong>hackers</strong> &mdash; to celebrate the year with food, drink, and friends both old and new. <strong>Saturday, December 5th, 7PM, at <a href="http://launchfishers.com/" target="_BLANK">Launch Fishers</a>'s New Location!</strong> North East side of Indianapolis, we will have the <em>fifth</em> annual Indy Hackers' Holiday Social. We welcome everyone -- Pythonistas, Javanese, COBOLians, Scalanites, PHPers, Rubyists, .NET nuts, Perlsians.... We might even have some hardcore functional programming zealots giving in to mutable state for a few hours. The best part? It is <em>completely</em> <strong>free</strong>.
             </p>
+            <p class="subtitle-paragraph margin-top-20 margin-bottom-50 clear-fix">
+              <strong>Update!</strong> You can't join us because this event is over. Like, <em>WAY</em> over. You can relive the excitement by checking out the <a href="https://thirdshift.smugmug.com/Indy-Hackers-2015/">pictures from the event</a>, as captured by official Holiday Social documentarian, <a href="https://twitter.com/thirdshift">@thirdshift</a>.
+            </p>
+
 
             <a href="https://www.eventbrite.com/e/indy-hackers-holiday-social-2015-tickets-19099804028" class="button-black clear-fix">
               <span class="click-here"></span>

--- a/public/holiday-social-2015/style/base.css
+++ b/public/holiday-social-2015/style/base.css
@@ -257,6 +257,13 @@ input,textarea,label
 	color:#000000;
 }
 
+.subtitle-paragraph a, .subtitle-paragraph a:hover {
+	color: black;
+	font-size: inherit;
+	font-family: inherit;
+	text-decoration: underline;
+}
+
 /******************************************************************************/
 /*  Background colors														  */
 /******************************************************************************/


### PR DESCRIPTION
Since [Garrett](https://github.com/thirdshift) has captured photos for almost all the prior socials, thought it made sense to add links to his galleries on all the old event pages. We should probably get his permission before actually shipping this tho.