### PR TITLE
Stylesheet links should not be relative

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,12 +14,12 @@
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Dosis:400,300,200,500,600,700,800" />
 
     = stylesheet_link_tag 'application'
-    <link rel="stylesheet" type="text/css" media="screen and (max-width:969px)" href="assets/responsive/width-0-969.css"/>
-    <link rel="stylesheet" type="text/css" media="screen and (max-width:767px)" href="assets/responsive/width-0-767.css"/>
-    <link rel="stylesheet" type="text/css" media="screen and (min-width:480px) and (max-width:969px)" href="assets/responsive/width-480-969.css"/>
-    <link rel="stylesheet" type="text/css" media="screen and (min-width:768px) and (max-width:969px)" href="assets/responsive/width-768-969.css"/>
-    <link rel="stylesheet" type="text/css" media="screen and (min-width:480px) and (max-width:767px)" href="assets/responsive/width-480-767.css"/>
-    <link rel="stylesheet" type="text/css" media="screen and (max-width:479px)" href="assets/responsive/width-0-479.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (max-width:969px)" href="/assets/responsive/width-0-969.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (max-width:767px)" href="/assets/responsive/width-0-767.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (min-width:480px) and (max-width:969px)" href="/assets/responsive/width-480-969.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (min-width:768px) and (max-width:969px)" href="/assets/responsive/width-768-969.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (min-width:480px) and (max-width:767px)" href="/assets/responsive/width-480-767.css"/>
+    <link rel="stylesheet" type="text/css" media="screen and (max-width:479px)" href="/assets/responsive/width-0-479.css"/>
 
     = favicon_link_tag "/favicon.png"
 
@@ -56,7 +56,7 @@
             %a{ :href => 'mailto:miles@indyhackers.org' }> miles@indyhackers.org
             \.
           %p
-            Just wanna chat? Hit us up at 
+            Just wanna chat? Hit us up at
             = link_to '@indyhackersorg', "https://twitter.com/indyhackersorg"
         #made-by.layout-50-right
           %h3 Crafted Lovingly but with Wild Abandon By


### PR DESCRIPTION
Stylesheet links were relative, causing the requests for CSS on the newsletter archive page to 404. 