### PR TITLE
Add front page link to Holiday Social

### DIFF
--- a/app/views/site/index.html.haml
+++ b/app/views/site/index.html.haml
@@ -18,6 +18,12 @@
         Indy Hackers is proud to present **Hacks && Happenings**, a monthly collection of projects and blog posts by local developers and special developer-centric events delivered straight to your inbox.
 
         You can [subscribe](http://indyhackers.us6.list-manage.com/subscribe?u=244b5370d41b5cf4146ec517c&id=b51f983563) now or [view the past issues](/newsletter/archive).
+    %br
+    %h2 The Holiday Social
+    %p
+      :markdown
+        This year's [Holiday Social](/holiday-social-2016/) is coming up. [Reserve your ticket](http://indy-hackers-holiday-social-2016.eventbrite.com) now, or bask in the warm glow of Holiday Socials past. ( [2015](https://thirdshift.smugmug.com/Indy-Hackers-2015/), [2014](http://thirdshift.smugmug.com/2014-Indy-Hackers-Holiday-Soci/), [2013](http://thirdshift.smugmug.com/Indy-Hackers-Holiday-Social/) and [2011](https://thirdshift.smugmug.com/Other/Other-1/Indy-Hackers-Holiday-2011/n-qM6NZ/) )
+
 
   .layout-50-right.text-center
     -# Scale Assembly should be the sponsor through August 17th, 2017!


### PR DESCRIPTION
Add a front page link to the Holiday Social page, as well as ticket registration link and link to photo galleries from previous years.