### PR TITLE
Logo cleanup

### DIFF
--- a/app/assets/stylesheets/base.erb.css
+++ b/app/assets/stylesheets/base.erb.css
@@ -334,6 +334,7 @@ h1 a,h2 a,h3 a,h4 a,h5 a,h6 a,
 	{
 		clear:both;
 		float:left;
+		line-height: normal;
 	}
 
 	.layout-50p-right
@@ -1215,9 +1216,10 @@ div.main-body
 
 		div.header div.header-phone
 		{
-			float:right;
-			text-transform:uppercase;
-			padding:10px 20px 12px 10px;
+	    float: right;
+	    line-height: normal;
+	    text-transform: uppercase;
+	    padding: 10px 20px 12px 10px;
 		}
 
 	/**************************************************************************/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Dosis:400,300,200,500,600,700,800" />
 
     = stylesheet_link_tag 'application'
+
     <link rel="stylesheet" type="text/css" media="screen and (max-width:969px)" href="/assets/responsive/width-0-969.css"/>
     <link rel="stylesheet" type="text/css" media="screen and (max-width:767px)" href="/assets/responsive/width-0-767.css"/>
     <link rel="stylesheet" type="text/css" media="screen and (min-width:480px) and (max-width:969px)" href="/assets/responsive/width-480-969.css"/>
@@ -60,8 +61,14 @@
             %a{ :href => 'https://docs.google.com/forms/d/e/1FAIpQLSdlfIqF42uU8iyoYyqKDFPEYRsNCOCFYpFJwMTvdVOkK3otSg/viewform?usp=sf_link' }> this form
             \.
           %p
+            Coming to one of our events? Cool!
+            %br
+            Check out our
+            =link_to 'Code of Conduct', '/coc'
+          %p
             Just wanna chat? Hit us up at
             = link_to '@indyhackersorg', "https://twitter.com/indyhackersorg"
+
         #made-by.layout-50-right
           %h3 Crafted Lovingly but with Wild Abandon By
           %ul.clear-fix

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -61,7 +61,7 @@
             %a{ :href => 'https://docs.google.com/forms/d/e/1FAIpQLSdlfIqF42uU8iyoYyqKDFPEYRsNCOCFYpFJwMTvdVOkK3otSg/viewform?usp=sf_link' }> this form
             \.
           %p
-            Coming to one of our events? Cool!
+            Coming to one of our events, or joining us on Slack? Cool!
             %br
             Check out our
             =link_to 'Code of Conduct', '/coc'


### PR DESCRIPTION
This fixes most of the header styling issues on the CoC page, as well as linking to the CoC page from the footer of the main site. 

The top right menu is still displaying a bit strangely, but I'm sick of messing with it, and I figure it's a small enough problem that it can wait for an impending style clean up.

Screenshot below:

<img width="1019" alt="screen shot 2017-06-07 at 7 21 26 pm" src="https://user-images.githubusercontent.com/27860/26905697-c37ca0d4-4bb6-11e7-88fd-426721f5d707.png">

