### PR TITLE
Redirect non-ssl requests to SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ IndyhackersRails::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug


### PR DESCRIPTION
This will force everyone onto HTTPS. Which is great for things like security, privacy, and SEO.