### PR TITLE
Add postgres service to fix travis and update badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.6.2
-
+services:
+  - postgresql
 before_script:
   - psql -c 'create database indyhackers_test;' -U postgres
   - cp config/database.yml.travis config/database.yml
 
 script:
   - RAILS_ENV=test bundle exec rake --trace db:migrate test
-
-env:
-  - DB=postgresql

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IndyHackers.org
 
 [![Build Status](https://travis-ci.org/indyhackers/indyhackers.org.svg?branch=master)](https://travis-ci.org/indyhackers/indyhackers.org)
-[![Code Climate](https://codeclimate.com/github/mileszs/indyhackers.org/badges/gpa.svg)](https://codeclimate.com/github/mileszs/indyhackers.org)
+[![Code Climate](https://codeclimate.com/github/indyhackers/indyhackers.org/badges/gpa.svg)](https://codeclimate.com/github/mileszs/indyhackers.org)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IndyHackers.org
 
-![TravisCI](https://travis-ci.org/mileszs/indyhackers.org.svg?branch=master)
+[![Build Status](https://travis-ci.org/indyhackers/indyhackers.org.svg?branch=master)](https://travis-ci.org/indyhackers/indyhackers.org)
 [![Code Climate](https://codeclimate.com/github/mileszs/indyhackers.org/badges/gpa.svg)](https://codeclimate.com/github/mileszs/indyhackers.org)
 
 ## Contributing


### PR DESCRIPTION
## Why?

Our Travis CI builds have been failing because they can't find a running instance of postgres

## What?

- Updates the travis.yml to specify that it needs postgres running using the service [directive](https://docs.travis-ci.com/user/database-setup/#postgresql)
- Cache the gem bundle between travis runs for faster re-runs https://docs.travis-ci.com/user/caching/#enabling-bundler-caching
- Updates the travis CI badge and codeclimate badges to point to the indyhackers organization version of the repo.

## Testing Notes

- [ ] Travis CI now passes 🎉 