### PR TITLE
Polish setup of new developer environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 ```
 git clone [your fork]
 cd indyhackers.org
-bundle install
-bundle exec rake db:setup
+bin/setup
 bundle exec rails s
 ```
 
 And, if you're on macOS or another OS with this command available to you, you can stay in the terminal but open your browser using `open http://localhost:3000`.
+
+To access the admin pages, visit `http://localhost:3000/admins/sign_in` and use the seeded admin `admin@example.com` with password `indyhacker`
 
 ## To Do
 

--- a/bin/setup
+++ b/bin/setup
@@ -22,10 +22,10 @@ chdir APP_ROOT do
   # system('bin/yarn')
 
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  unless File.exist?('config/database.yml')
+    puts "\n== Copying database.yml.sample =="
+    cp 'config/database.yml.sample', 'config/database.yml'
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,0 +1,16 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  host: localhost
+  username: postgres
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development:
+  <<: *default
+  database: indyhackers_development
+
+test:
+  <<: *default
+  database: indyhackers_test

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,8 @@ Job.create(
   description: 'Badass stuff',
   published_at: 2.days.ago
 )
+
+Admin.create(
+  email: "admin@example.com",
+  password: "indyhacker"
+)


### PR DESCRIPTION
## Description

When setting up a new environment, a developer has to create a
database.yml from scratch in order to complete setup. This adds a
database.yml.sample that can be copied over and makes use of it in the
bin/setup script. The readme was changed to reference the bin/setup
script in the instructions for setting up a new environment.

One other minor paint point was setting up and accessing the admin pages
for the first time. To help with this, I added an admin user to the seed
file and instructions in the readme on how to access the admin pages
with that user.

## Testing Notes

- Running bin/setup will now copy the database.yml.sample over to database.yml unless one already exists
- Running `rake db:seed` will now create an admin user (it will also create an admin user when db:setup is called in bin/setup)
