### PR TITLE
Do not delete jobs; only show active jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -4,7 +4,7 @@ class JobsController < ApplicationController
   skip_before_action :verify_authenticity_token, :only => :viewed
 
   def index
-    @jobs = Job.published.order("created_at DESC").all
+    @jobs = Job.active.order("created_at DESC")
     respond_to do |format|
       format.html
       format.atom { render :layout => false }

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -3,7 +3,7 @@ class SitemapsController < ApplicationController
   caches_action :show
 
   def show
-    @jobs = Job.published
+    @jobs = Job.active
     @posts = Post.published
     @other_routes = ["/","/jobs","/job_post_request","/calendar", "/why_indy"]
     respond_to do |format|

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,13 +10,24 @@ class Job < ActiveRecord::Base
 
   after_update :notify_if_published
 
-  scope :published, lambda {
-    where("jobs.published_at IS NOT NULL AND jobs.published_at <= ?", Time.zone.now)
-  }
+  class << self
+    # Jobs that should appear in public listings
+    #
+    # @returns [ActiveRecord::Relation<Job>] active jobs
 
-  scope :stale, lambda {
-    where("created_at < ?", 60.days.ago)
-  }
+    def active
+      published.where("jobs.published_at >= ?", 60.days.ago)
+    end
+
+    private
+
+    def published
+      where(
+        "jobs.published_at IS NOT NULL AND jobs.published_at <= ?",
+        Time.zone.now
+      )
+    end
+  end
 
   def name
     "#{title} at #{company}"

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -11,7 +11,7 @@
       Have an open position at your company? It is completely free to submit a job to our job board! Each job remains published for 60 days, and will be included in our newsletter while published. Please [submit your job here](/job_post_requests/new), and mind our [Job Board Policy](https://github.com/indyhackers/job_board_policy). Thank you!
 
 .job-list
-  - if @jobs.empty?
+  - if @jobs.blank?
     %p
       There are no job postings at this time. Check back later, or
       %a{:href =>'http://indyhackers.org/jobs.xml'}subsribe to the feed.

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -1,9 +1,4 @@
 namespace :admin do
-  desc 'Remove stale jobs (and dependents)'
-  task :sweep_jobs => :environment do
-    Job.stale.destroy_all
-  end
-
   desc "If the title already contains 'at Company Name', remove it and put it in the company field"
   task :fix_job_titles => :environment do
     Job.where(company: nil).each do |job|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,22 @@ FactoryGirl.define do
   factory :job do
     title Faker::Lorem.words.join(' ')
     description Faker::Lorem.paragraphs.join
+
+    trait :unpublished do
+      published_at nil
+    end
+
+    trait :published do
+      published_at { 1.day.ago }
+    end
+
+    trait :published_in_future do
+      published_at { 1.day.from_now }
+    end
+
+    trait :no_longer_active do
+      published_at { 61.days.from_now }
+    end
   end
 
   factory :admin do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -1,14 +1,19 @@
 require 'spec_helper'
 
 describe Job do
-  context "#stale" do
-    it "scopes results to jobs older than 60 days" do
-      @stale_job = FactoryGirl.create(:job, :created_at => 61.days.ago)
-      @fresh_job = FactoryGirl.create(:job, :created_at => 59.day.ago)
-      
-      results = Job.stale
-      expect(results).to include(@stale_job)
-      expect(results).not_to include(@fresh_job)
+  context "#active" do
+    it "only includes jobs that are published and active" do
+      @unpublished_job = create(:job, :unpublished)
+      @future_published_job = create(:job, :published_in_future)
+      @published_job = create(:job, :published)
+      @no_longer_active_job = create(:job, :no_longer_active)
+
+      results = Job.active
+
+      expect(results).to include(@published_job)
+      expect(results).not_to include(@unpublished_job)
+      expect(results).not_to include(@future_published_job)
+      expect(results).not_to include(@no_longer_active_job)
     end
   end
 end

--- a/spec/requests/viewing_jobs_spec.rb
+++ b/spec/requests/viewing_jobs_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "ViewingJobs", type: :request do
+  describe "GET /jobs" do
+    it "Displays active jobs" do
+      published_job = create(:job, :published, title: "A published job")
+      not_active_job = create(:job, :no_longer_active, title: "Not active job")
+
+      get jobs_path
+
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(published_job.title)
+      expect(response.body).not_to include(not_active_job.title)
+    end
+  end
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
## Why?
Resolves #81
Resolves #107

Per #81 we don't want to delete job listing that are no longer active so we have them for historical reference but we don't want to show them in public listings after they are no longer active. This is the approach I was outlining in my comment in that issue; let me know what ya think! Since it wasn't a lot of code, I thought a PR might help make it clearer what change was being proposed.

This also fixes a potential issue with jobs being "swept" before they were shown the full 60 days if the created_at and published_at dates were not the same; see #107 for more details.

### Possible future ideas building on this

A possible future addition might be to allow a posting to be "re-posted", possibly by creating a job using an old one as a template?

Maybe simpler would be for a job posting to have it's "window" extended, so maybe instead of having a fixed 60 day window we make that default configurable by job and then use that when determining if a job is still active. That would allow a job to stay open for longer if it needed to be without changing the published_at date or creating a new listing.

## What?
Introduces the concept of active job postings. Job listings are shown in public listings if they are active but are no longer destroyed when they are no longer active. Instead they are just no longer shown on the job board.

This also updates the sitemap that is there for the web-crawlers so it only sees active jobs (similar to how it only say published jobs before).

Since it uses the same controller action, this also impacts the atom/RSS feed (it will still only show jobs that appear on the job board, which are now the "active" jobs).

## Testing Notes

There are automated tests, but additionally in local testing I:
- moved the published_at date forward and backward to make sure a job posted anywhere from now to 60 days ago showed up on the job board (but did not outside of that range)
- created 3 jobs and made sure the most recent job showed at the top and the other in descending order by created_at
- checked that a job with `nil` published_at did not appear on the job board.

## On Deploy

- [ ] Be sure to remove the `sweep_jobs` rake task from the heroku scheduler. If we don't do this, it will through an exception because the task won't exist anymore 😬 
