### PR TITLE
Add active filter and pagination for admin jobs index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'simple_form'
 gem 'devise', "4.7.3"
 gem 'maruku'
 gem 'redcarpet'
-gem 'will_paginate'
+gem 'kaminari'
 
 gem 'stringex'
 gem 'slugged'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'haml', '~> 5.1.2'
 gem 'sassc'
 gem 'jquery-rails'
 gem 'simple_form'
-gem 'inherited_resources'
 
 gem 'devise', "4.7.3"
 gem 'maruku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json_pure (2.3.1)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.3)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -268,7 +280,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    will_paginate (3.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
@@ -292,6 +303,7 @@ DEPENDENCIES
   instrumental_agent
   jquery-rails
   json_pure
+  kaminari
   launchy
   maruku
   memcachier
@@ -314,7 +326,6 @@ DEPENDENCIES
   uglifier
   unicorn
   webdrivers
-  will_paginate
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,17 +110,9 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
-    has_scope (0.7.2)
-      actionpack (>= 4.1)
-      activesupport (>= 4.1)
     hpricot (0.8.6)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    inherited_resources (1.11.0)
-      actionpack (>= 5.0, < 6.1)
-      has_scope (~> 0.6)
-      railties (>= 5.0, < 6.1)
-      responders (>= 2, < 4)
     instrumental_agent (2.1.0)
       metrician
     jquery-rails (4.4.0)
@@ -297,7 +289,6 @@ DEPENDENCIES
   foreman
   haml (~> 5.1.2)
   hpricot
-  inherited_resources
   instrumental_agent
   jquery-rails
   json_pure

--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -61,3 +61,16 @@ li#jobs-header h1 {
   color: white;
   background-color: black;
 }
+
+
+body.admin.jobs {
+  nav {
+    margin-top: 10px;
+    text-align: center;
+  }
+
+  #job-view-filter {
+    float: right;
+    clear: left;
+  }
+}

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -12,6 +12,8 @@ class Admin::JobsController < ApplicationController
       @jobs = @jobs.active
     when 'expired'
       @jobs = @jobs.expired
+    when 'unpublished'
+      @jobs = @jobs.unpublished
     end
 
     @jobs = @jobs.page(params[:page])

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -1,31 +1,50 @@
-class Admin::JobsController < InheritedResources::Base
-  respond_to :html
-
+class Admin::JobsController < ApplicationController
   before_action :authenticate_admin!
+  before_action :fetch_job, only: [:show, :edit, :update, :destroy]
   skip_before_action :verify_authenticity_token, :only => :destroy
+
+  def index
+    @jobs = Job.order(created_at: :desc)
+  end
+
+  def show
+  end
 
   def new
     @job = Job.new
   end
 
+  def edit
+  end
+
+  def create
+    @job = Job.new(job_params)
+
+    if @job.save
+      redirect_to admin_job_path(@job), :notice => 'Job was successfully created.'
+    else
+      render :new
+    end
+  end
+
   def update
-    @job = resource
     if @job.update(job_params)
-      redirect_to @job, :notice => 'Job was updated successfully'
+      redirect_to job_path(@job), :notice => 'Job was updated successfully'
     else
       render :edit
     end
   end
 
-  def collection
-    @jobs = Job.order("created_at DESC").all
-  end
-
-  def resource
-    @job = Job.find_using_slug(params[:id])
+  def destroy
+    @job.destroy
+    redirect_to admin_jobs_path, notice: 'Job was successfully destroyed.'
   end
 
   private
+
+  def fetch_job
+    @job = Job.find_using_slug(params[:id])
+  end
 
   def job_params
     params.require(:job).permit(:title, :description, :company, :published_at)

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -5,6 +5,16 @@ class Admin::JobsController < ApplicationController
 
   def index
     @jobs = Job.order(created_at: :desc)
+
+    params[:job_view]  ||= 'all'
+    case params[:job_view]
+    when 'active'
+      @jobs = @jobs.active
+    when 'expired'
+      @jobs = @jobs.expired
+    end
+
+    @jobs = @jobs.page(params[:page])
   end
 
   def show

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -1,2 +1,12 @@
 module JobsHelper
+  def job_view_links
+    ['all', 'active', 'expired'].map do |filter_type|
+      label = "#{filter_type.titleize} Jobs"
+      if params[:job_view] == filter_type
+        tag.span label
+      else
+        link_to label, admin_jobs_path(page: params[:page], job_view: filter_type)
+      end
+    end.join(" | ").html_safe
+  end
 end

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -1,6 +1,6 @@
 module JobsHelper
   def job_view_links
-    ['all', 'active', 'expired'].map do |filter_type|
+    ['all', 'unpublished', 'active', 'expired'].map do |filter_type|
       label = "#{filter_type.titleize} Jobs"
       if params[:job_view] == filter_type
         tag.span label

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -11,12 +11,12 @@ class Job < ActiveRecord::Base
   after_update :notify_if_published
 
   class << self
-    # Jobs that should appear in public listings
-    #
-    # @returns [ActiveRecord::Relation<Job>] active jobs
-
     def active
       published.where("jobs.published_at >= ?", 60.days.ago)
+    end
+
+    def expired
+      published.where("jobs.published_at < ?", 60.days.ago)
     end
 
     private

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -12,20 +12,22 @@ class Job < ActiveRecord::Base
 
   class << self
     def active
-      published.where("jobs.published_at >= ?", 60.days.ago)
+      published.where("jobs.published_at >= :date", date: 60.days.ago)
     end
 
     def expired
-      published.where("jobs.published_at < ?", 60.days.ago)
+      published.where("jobs.published_at < :date", date: 60.days.ago)
+    end
+
+    def unpublished
+      where(published_at: nil)
     end
 
     private
 
     def published
-      where(
-        "jobs.published_at IS NOT NULL AND jobs.published_at <= ?",
-        Time.zone.now
-      )
+      where.not(published_at: nil)
+        .where("published_at <= :date", date: Time.zone.now)
     end
   end
 

--- a/app/views/admin/jobs/edit.html.haml
+++ b/app/views/admin/jobs/edit.html.haml
@@ -2,7 +2,7 @@
   = javascript_include_tag 'showdown'
 
 %li.readable
-  = simple_form_for resource, :url => admin_job_path(resource), :html => {:multipart => true} do |f|
+  = simple_form_for @job, :url => admin_job_path(@job), :html => {:multipart => true} do |f|
     %fieldset
       %legend Edit Job
       = f.input :title
@@ -10,7 +10,7 @@
       = f.input :description
       = f.input :published_at, :as => :date
       .if-no-contact
-        = "If they didn't leave a way to apply, append this to the bottom: \"To apply, please contact [#{resource.try(:user).try(:name)}](mailto:#{resource.try(:user).try(:email)})"
+        = "If they didn't leave a way to apply, append this to the bottom: \"To apply, please contact [#{@job.try(:user).try(:name)}](mailto:#{@job.try(:user).try(:email)})"
       .input
         %label &nbsp;
         = f.button :submit, 'Save'

--- a/app/views/admin/jobs/index.html.haml
+++ b/app/views/admin/jobs/index.html.haml
@@ -1,6 +1,7 @@
 %li
   %h2 Jobs
 
+  #job-view-filter= job_view_links
   %p= link_to 'Create a New Job', new_admin_job_path, :class => 'button-black'
   %table#jobs
     %tr
@@ -17,3 +18,4 @@
           = link_to 'edit', edit_admin_job_path(job), :title => 'edit'
           |
           = link_to 'delete', admin_job_path(job), :method => :delete, :title => 'delete', :confirm => 'Are you sure you wanna destroy this job?'
+  = paginate(@jobs)

--- a/app/views/admin/jobs/index.html.haml
+++ b/app/views/admin/jobs/index.html.haml
@@ -8,7 +8,7 @@
       %th Requested
       %th Published
       %th Actions
-    - collection.each do |job|
+    - @jobs.each do |job|
       %tr
         %td= job.name
         %td= l(job.created_at, :format => :murican)

--- a/app/views/admin/jobs/show.html.haml
+++ b/app/views/admin/jobs/show.html.haml
@@ -1,5 +1,4 @@
-.job.readable
-  %h3
-    = resource.title
-  .job-description
-    = MARKDOWN.render(resource.description).html_safe
+%li.job#single-job
+  %h1= @job.name
+  %article.job-description
+    = MARKDOWN.render(@job.description).html_safe

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     end
 
     trait :no_longer_active do
-      published_at { 61.days.from_now }
+      published_at { 61.days.ago }
     end
   end
 

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -52,4 +52,38 @@ RSpec.describe "Admin feature" do
     expect(page).to have_text(/success/)
     expect(page).to have_text(new_title.upcase)
   end
+
+  it "allows an admin to view only active jobs" do
+    admin = create(:admin)
+    active_job = create(:job, :published, user: create(:user))
+    expired_job = create(:job, :no_longer_active, user: create(:user))
+
+    visit new_admin_session_path
+    fill_in "Email", with: admin.email
+    fill_in "Password", with: "password"
+    click_on "Sign in"
+
+    visit admin_jobs_path
+    click_on "Active Jobs"
+
+    expect(page).to have_text(active_job.title)
+    expect(page).not_to have_text(expired_job.title)
+  end
+
+  it "allows an admin to view only expired jobs" do
+    admin = create(:admin)
+    active_job = create(:job, :published, user: create(:user))
+    expired_job = create(:job, :no_longer_active, user: create(:user))
+
+    visit new_admin_session_path
+    fill_in "Email", with: admin.email
+    fill_in "Password", with: "password"
+    click_on "Sign in"
+
+    visit admin_jobs_path
+    click_on "Expired Jobs"
+
+    expect(page).not_to have_text(active_job.title)
+    expect(page).to have_text(expired_job.title)
+  end
 end


### PR DESCRIPTION
Closes #118 

## The Problem

"In #108 we stopped deleting jobs from the job board - we only expire them now. This is great, but now the jobs list at /admin/jobs has a long list and it's hard to tell what's expired and what's active."

## The Solution

- Removed `inheritied_resources`. It was used in one whole controller and even then a lot of its default stuff was being overridden. `Admin::JobsController` is now more or less a standard Rails crud controller.
- Swapped out `will_paginate` for `kaminari`. There's nothing in the app doing pagination and kaminari is at least a bit more modern than will_paginate as well as more customizable.
- Implemented an `expired` "scope" on `Job` which is basically the inverse of `active`.
- For `Admin::JobsController#index`, I implemented a quick-n-dirty filter for calling the active, expired, or no scope on the jobs collection. This is controlled by the most likely poorly named "job_view" param. This param defaults to "all". The index view calls a view helper to render out three quick links to set the filter. I also added basic pagination to the whole page.

![Screenshot 2020-10-18 172457](https://user-images.githubusercontent.com/545604/96386161-e3bbbc80-1166-11eb-9f1d-074e5cdfaf1d.png)


In the future, if we wish to implement more filtering and sorting on the admin jobs page, we can probably implement ransack at that time. For now, a single filter like this is simple enough to implement ourselves.