### PR TITLE
Improving readability of multiple jobs pages

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -5,6 +5,26 @@
 #single-job h1 {
   font-size: 36px;
 }
+
+#single-job h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: black;
+  text-transform: none;
+
+  &:not(:first-child) {
+    margin-top: 0.5em;
+  }
+}
+
+#single-job a {
+  color: black;
+  text-decoration: underline;
+}
+
 #single-job article.job-description h1 {
   font-size: 24px;
 }

--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -49,10 +49,10 @@ li#jobs-header h1 {
 }
 
 .job-list li a {
+  color: black;
   font-size: 20px;
-  font-weight: 400;
+  font-weight: 500;
   font-family: 'Dosis';
-  text-transform: uppercase;
   display: block;
   padding: 15px;
 }
@@ -61,7 +61,6 @@ li#jobs-header h1 {
   color: white;
   background-color: black;
 }
-
 
 body.admin.jobs {
   nav {

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Admin feature" do
     end.to change(Job, :count).by(1)
 
     expect(page).to have_text(/success/)
-    expect(page).to have_text(title.upcase)
+    expect(page).to have_text(title)
     expect(page).to have_text(description)
   end
 
@@ -50,7 +50,7 @@ RSpec.describe "Admin feature" do
     click_on "Save"
 
     expect(page).to have_text(/success/)
-    expect(page).to have_text(new_title.upcase)
+    expect(page).to have_text(new_title)
   end
 
   it "allows an admin to view only active jobs" do

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Jobs feature" do
     job = create(:job, :published, user: create(:user))
 
     visit jobs_path
-    expect(page).to have_text(job.name.upcase)
+    expect(page).to have_text(job.name)
 
     click_on job.name
     expect(page).to have_text(job.description)


### PR DESCRIPTION
# Overview

Resolves #111 

This PR makes a handful of accessibility a readability improvements on a few jobs pages. On the paging listing jobs, it sets the text color of jobs to black, removes `text-transform: uppercase`, and increases the `font-weight` from 400 to 500. On the page where new job listings can be requested (the preview) and on listing pages, headings where updated to have black text, no `text-transform` set (this property is being set to `uppercase elsewhere`, and a `margin-top` (because some headings didn't have any margin on top at all). These pages also have links in the descriptions set to have black text and an underline. Links outside of the job description are not affected by this change because that seemed like a site-wide issue that should be addressed serparately.

As for text size on mobile, I was hoping this fix would be as easy as adding this line to `app/views/layouts/application.html.haml`:

```
%meta{:name => "viewport", :content => "width=device-width,initial-scale=1"}/
```

Unfortunately, it's not that straightforward and it makes a lot of other text really hard to read. I think it would also affect realistic job descriptions with a lot of text and the text would run off the side of the screen. See this screenshot for a small example:

![CleanShot 2021-03-29 at 14 00 13](https://user-images.githubusercontent.com/43934258/112880224-29769c80-9098-11eb-8402-38c12abfce23.png)

# Testing

Here's what the jobs list should look like with improved casing, color, and weight. The second item in the list doesn't show my cursor, but it shows what the hover state looks like.

![CleanShot 2021-03-29 at 13 54 05](https://user-images.githubusercontent.com/43934258/112878741-4a3df280-9096-11eb-8206-e726c242bfdd.png)

Here's what the job listing request page looks like in preview mode. It shows headings with improved casing, color, and spacing above them and it also shows how links will look with black text and an underline.

![CleanShot 2021-03-29 at 13 58 24](https://user-images.githubusercontent.com/43934258/112879196-d9e3a100-9096-11eb-927b-147a69e929df.png)
