### PR TITLE
Show salary on the jobs feed

### DIFF
--- a/app/views/jobs/index.atom.builder
+++ b/app/views/jobs/index.atom.builder
@@ -4,9 +4,8 @@ atom_feed language: 'en-US' do |feed|
 
   @jobs.each do |job|
     feed.entry(job) do |entry|
-      title = job.title
-      title += ' (' + job.salary + ')' unless job.salary.blank?
-      entry.title(title)
+      salary = job.salary.present? ? " (#{job.salary})" : ''
+      entry.title("#{job.title}#{salary}")
       entry.content(MARKDOWN.render(job.description).html_safe, type: 'html')
       entry.author do |author|
         author.name('IndyHackers')

--- a/app/views/jobs/index.atom.builder
+++ b/app/views/jobs/index.atom.builder
@@ -1,11 +1,13 @@
-atom_feed :language => 'en-US' do |feed|
-  feed.title("IndyHackers Job Board")
+atom_feed language: 'en-US' do |feed|
+  feed.title('IndyHackers Job Board')
   feed.updated(@jobs.first.created_at)
 
   @jobs.each do |job|
     feed.entry(job) do |entry|
-      entry.title(job.title)
-      entry.content(MARKDOWN.render(job.description).html_safe, :type => 'html')
+      title = job.title
+      title += ' (' + job.salary + ')' unless job.salary.blank?
+      entry.title(title)
+      entry.content(MARKDOWN.render(job.description).html_safe, type: 'html')
       entry.author do |author|
         author.name('IndyHackers')
       end


### PR DESCRIPTION
This is the feed that goes to #jobs in slack. It puts the salary in the post title in parentheses when a salary is provided.