### PR TITLE
Add slack link to homepage in prominent spot

### DIFF
--- a/app/assets/stylesheets/content.scss
+++ b/app/assets/stylesheets/content.scss
@@ -27,7 +27,7 @@
   .slack {
     padding: 30px 0 30px 20%;
 
-    a.join-slack {
+    a.join-slack, a.code-of-conduct {
       text-decoration-color: $text-color-black;
     }
   }

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -10,8 +10,8 @@
 </section>
 <section class="two-columns announcements" data-section="announcement">
   <div class="container slack">
-    <h2>Join us on Slack!</h2>
-    <p>Our Slack group brings hackers, programmers, makers, and tech folks of all kinds together. You're invited - don't forget to check out our Code of Conduct first!</p>
+    <h2><a href="https://slack.indyhackers.org">Join us on Slack!</a></h2>
+    <p>Our Slack group brings hackers, programmers, makers, and tech folks of all kinds together. You're invited - don't forget to check out our <a href="/coc" class="code-of-conduct">Code of Conduct</a> first!</p>
     <p><a href="https://slack.indyhackers.org" class="join-slack">Slack it to me!</a></p>
   </div>
   <div class="container hackies">


### PR DESCRIPTION
Adds a section to the homepage to promote the Slack community per #101 

Looks like this:
<img width="2114" alt="Screen Shot 2021-10-10 at 12 17 22 PM" src="https://user-images.githubusercontent.com/5497970/136704334-66950996-bb81-439b-b676-ce8a0aae8491.png">
