### PR TITLE
Add jump link to event calendar

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,6 +29,7 @@
         %ul.menu
           %li= link_to 'Newsletter', '/newsletter'
           %li= link_to 'Jobs', '/jobs'
+          %li= link_to 'Event Calendar', '/#event-calendar'
           %li= link_to 'About', '/about'
 
       .content.clear-fix

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,7 +29,7 @@
         %ul.menu
           %li= link_to 'Newsletter', '/newsletter'
           %li= link_to 'Jobs', '/jobs'
-          %li= link_to 'Event Calendar', '/#event-calendar'
+          %li= link_to 'Events', '/#event-calendar'
           %li= link_to 'About', '/about'
 
       .content.clear-fix

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -45,7 +45,7 @@
     </div>
   </div>
 </section>
-<section class="container">
+<section class="container" id="event-calendar">
   <h2>Our calendar</h2>
   <iframe src="//www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com&amp;color=%23AB8B00&amp;ctz=America%2FNew_York" style="border-width:0 " width="710" height="400" frameborder="0" scrolling="no"></iframe>
   <div class="calendar-links">


### PR DESCRIPTION
It's not obvious there's an event calendar unless you are on the home page and scroll all the day down.

- Added a jump link in the main navigation pointing to the homepage and to an id for the `<section>` around the event calendar.