### PR TITLE
Add matrix gem, postgres for asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 ruby 3.1.2
+postgres 15.2

--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,5 @@ group :test do
 
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'matrix'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     maruku (0.7.3)
+    matrix (0.4.2)
     memcachier (0.0.2)
     method_source (1.0.0)
     mime-types (1.25.1)
@@ -334,6 +335,7 @@ DEPENDENCIES
   launchy
   listen (~> 3.3)
   maruku
+  matrix
   memcachier
   net-imap
   net-pop


### PR DESCRIPTION
I added `postgres` to `.tool-versions` for those of using `asdf`.

When I went to run the specs, I was told I needed the `matrix` gem installed, so I added it to the test group. 