### PR TITLE
Cleanup admin styles & job table

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -5,3 +5,5 @@ $dark-gray: #6F6F6F;
 $header-font: 'Space Mono', monospace;
 $text-font: 'Work Sans', sans-serif;
 
+$development: #069a41;
+$production: #9a0606;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,20 @@
+@import '_variables';
+
+$notice-danger-color: #ff3838;
+$notice-warning-color: #ffba00;
+$notice-success-color: #2ec946;
+
+.notice {
+  width: 100%;
+  padding: 16px;
+  margin: 8px;
+  background-color: $notice-success-color;
+
+  .danger {
+    background-color: $notice-danger-color;
+  }
+
+  .warning {
+    background-color: $notice-warning-color;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,7 +2,6 @@
  *= require_self
  *= require jquery.qtip
  *= require jquery-ui/jquery-ui
- *= require base
  *= require main
  *= require atoms
  *= require header
@@ -12,4 +11,5 @@
  *= require about
  *= require content
  *= require simple_form
+ *= require admin
  */

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -52,8 +52,8 @@
 
 #admin-header {
   display: flex;
-  justify-content: flex-end;
   width: 100%;
+  border-bottom: 1px solid #ccc;
 
   div.left {
     padding: 20px;
@@ -61,5 +61,32 @@
 
   div.right {
     padding: 20px;
+    margin-left: auto;
+  }
+
+  a {
+    padding: 12px 24px;
+    text-decoration: none;
+    background-color: white;
+    color: $text-color-black;
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-color: #FFC000;
+    }
+  }
+
+  h1 {
+    font-size: 36px;
+    margin: 0;
+    padding: 0;
+  }
+
+  &.development {
+    color: $development;
+  }
+
+  &.production {
+    color: $production;
   }
 }

--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -41,12 +41,32 @@ table#jobs {
   width: 100%;
 }
 
-table#jobs tr td {
-  margin: 0;
-  padding: 6px 16px 6px 0;
-  border-top: 1px solid #000;
-  border-collapse: collapse;
-  overflow: hidden;
+table#jobs {
+  border-spacing: 0;
+
+  tr {
+    margin: 0;
+    padding: 0;
+    
+    td {
+      padding: 6px;
+      margin: 0;
+      border-top: 1px solid #000;
+      border-collapse: collapse;
+      overflow: hidden;
+    }
+  }
+
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  td.actions,
+  td.requested,
+  td.published {
+    text-align: center;
+
+  }
 }
 
 li#jobs-header h1 {

--- a/app/views/admin/jobs/index.html.haml
+++ b/app/views/admin/jobs/index.html.haml
@@ -12,8 +12,8 @@
     - @jobs.each do |job|
       %tr
         %td= job.name
-        %td= l(job.created_at, :format => :murican)
-        %td= l(job.published_at, :format => :murican) unless job.published_at.nil?
+        %td.requested= l(job.created_at, :format => :murican)
+        %td.published= l(job.published_at, :format => :murican) unless job.published_at.nil?
         %td.actions
           = link_to 'edit', edit_admin_job_path(job), :title => 'edit'
           |

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,11 +34,11 @@
 
       .content.clear-fix
         - if notice
-          %section.text-center.clear-fix
+          %section
             .notice= notice
         - if alert
-          %section.text-center.clear-fix
-            .alert= alert
+          %section
+            .alert.danger= alert
         = yield
 
       .footer

--- a/app/views/shared/_admin_header.html.haml
+++ b/app/views/shared/_admin_header.html.haml
@@ -1,8 +1,8 @@
 #admin-header{:class => "#{Rails.env}"}
   .left
-    %p= Rails.env
+    %h1= Rails.env
   .right
     %p
-      = link_to 'jobs', admin_jobs_path, :class => 'button-yellow'
-      = link_to 'logout', destroy_admin_session_path, :class => 'button-yellow'
+      = link_to 'jobs', admin_jobs_path
+      = link_to 'logout', destroy_admin_session_path
   .clear &nbsp;

--- a/app/views/shared/admin_header.html.haml
+++ b/app/views/shared/admin_header.html.haml
@@ -1,5 +1,0 @@
-#admin-header{:class => "#{Rails.env}"}
-  %span.left= Rails.env
-  %span.right
-    = link_to 'Jobs', admin_jobs_path
-    = link_to 'Posts', admin_posts_path


### PR DESCRIPTION
The admin area of the site could use a bit of cleanup to make it easier / more pleasant to use. It could honestly use more than what I've done here, but this is a start.

<img width="1530" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/c49c4e63-2f44-4177-bf13-7ae27e5b583d">

<img width="1174" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/88f38d35-cbfa-46e4-aa8d-8e53aef5b322">


1. Separate the admin bar at the top of the screen to give a clear delineation between it and the normal content of the page.
2. Put the env name on the left, admin nav on the right.
3. Style the notice and alert messages to differentiate them from the rest of the content.
4. Cleanup the jobs table styling a wee bit because it causes me something akin to indigestion to see it. 

<img width="1653" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/6ad0e2cd-d5b9-4f16-973a-47c319a35437">

<img width="1635" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/26797b62-a2bb-4dba-bd06-1653d8b4d638">
