### PR TITLE
Add and enable SimpleCov

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -38,7 +38,13 @@ jobs:
         run: bin/rails db:schema:load
       # Add or replace test runners here
       - name: Run tests
-        run: bin/rake
+        run: COVERAGE=true bin/rake
+      - name: Upload coverage results
+        uses: actions/upload-artifact@master
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage
 
   lint:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ group :test do
   gem "factory_bot_rails"
   gem "faker"
   gem "matrix"
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -296,6 +297,12 @@ GEM
     simple_form (5.2.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slugged (2.0.0)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
@@ -375,6 +382,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   simple_form
+  simplecov
   slugged
   spork
   stringex

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,15 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
-#
+
+require "simplecov"
+if ENV.fetch("COVERAGE", false)
+  SimpleCov.start do
+    minimum_coverage 90
+    maximum_coverage_drop 2
+  end
+end
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Add and enable SimpleCov with a threshold of 90% (we're currently at 95%!) and a drop allowed of 2%. 

I think that 90% is excessive if you're not already there, but considering we're at 95% and there's a controller action I think should be tested that isn't, I'm pretty happy with sticking at 90%. 

I also added it to the GitHub Action. We'll see how that goes here shortly...