### PR TITLE
Move job view counting to #show

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -63,9 +63,9 @@ table#jobs {
 
   td.actions,
   td.requested,
-  td.published {
+  td.published,
+  td.views {
     text-align: center;
-
   }
 }
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -61,14 +61,18 @@ class Job < ActiveRecord::Base
   end
 
   def notify_if_published
-    if saved_change_to_published_at? && published_at.present? && published_at <= Time.now
-      SystemMailer.job_post_published(user, self).deliver_now
-    else
-      Rails.logger.info "OMG WTF BBQ"
-    end
+    return unless recently_published?
+
+    SystemMailer.job_post_published(user, self).deliver_now
   end
 
   def increment_views
     self.views = views.nil? ? 1 : views + 1
+  end
+
+  private
+
+  def recently_published?
+    saved_change_to_published_at? && published_at.present? && published_at <= Time.now
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -67,4 +67,8 @@ class Job < ActiveRecord::Base
       Rails.logger.info "OMG WTF BBQ"
     end
   end
+
+  def increment_views
+    self.views = views.nil? ? 1 : views + 1
+  end
 end

--- a/app/views/admin/jobs/index.html.haml
+++ b/app/views/admin/jobs/index.html.haml
@@ -8,12 +8,14 @@
       %th Name
       %th Requested
       %th Published
+      %th Views
       %th Actions
     - @jobs.each do |job|
       %tr
         %td= job.name
         %td.requested= l(job.created_at, :format => :murican)
         %td.published= l(job.published_at, :format => :murican) unless job.published_at.nil?
+        %td.views= job.views || 0
         %td.actions
           = link_to 'edit', edit_admin_job_path(job), :title => 'edit'
           |

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Job do
-  describe "#active" do
+  describe "::active" do
     it "only includes jobs that are published and active" do
       unpublished_job = create(:job, :unpublished)
       future_published_job = create(:job, :published_in_future)
@@ -14,6 +14,89 @@ RSpec.describe Job do
       expect(results).not_to include(unpublished_job)
       expect(results).not_to include(future_published_job)
       expect(results).not_to include(no_longer_active_job)
+    end
+  end
+
+  describe "::expired" do
+    it "only includes jobs that are expired" do
+      unpublished_job = create(:job, :unpublished)
+      future_published_job = create(:job, :published_in_future)
+      published_job = create(:job, :published)
+      no_longer_active_job = create(:job, :no_longer_active)
+
+      results = Job.expired
+
+      expect(results).not_to include(published_job)
+      expect(results).not_to include(unpublished_job)
+      expect(results).not_to include(future_published_job)
+      expect(results).to include(no_longer_active_job)
+    end
+  end
+
+  describe "::unpublished" do
+    it "only includes jobs that are unpublished" do
+      unpublished_job = create(:job, :unpublished)
+      future_published_job = create(:job, :published_in_future)
+      published_job = create(:job, :published)
+      no_longer_active_job = create(:job, :no_longer_active)
+
+      results = Job.unpublished
+
+      expect(results).not_to include(published_job)
+      expect(results).to include(unpublished_job)
+      expect(results).not_to include(future_published_job)
+      expect(results).not_to include(no_longer_active_job)
+    end
+  end
+
+  describe "#name" do
+    it "returns the job title and company" do
+      job = build(:job)
+      expect(job.name).to include(job.title)
+      expect(job.company).to include(job.company)
+    end
+  end
+
+  describe "#name_changed?" do
+    it "is true if the job title has changed" do
+      job = create(:job)
+      job.title = "New fancier title"
+      expect(job.name_changed?).to be_truthy
+    end
+
+    it "is true if the job company has changed" do
+      job = create(:job)
+      job.company = "New fancier company name"
+      expect(job.name_changed?).to be_truthy
+    end
+  end
+
+  describe "#notify_if_published" do
+    it "sends an email if the job was just published" do
+      user = create(:user)
+      job = create(:job, :unpublished, user: user)
+      mail_double = double
+      allow(mail_double).to receive(:deliver_now)
+
+      expect(SystemMailer).to receive(:job_post_published).with(user, job).and_return(mail_double)
+      job.published_at = 5.seconds.ago
+      job.save!
+    end
+  end
+
+  describe "#increment_views" do
+    it "when not yet viewied, sets the job views to 1" do
+      published_job = build(:job, :published)
+      expect(published_job.views).to be_nil
+      published_job.increment_views
+      expect(published_job.views).to eq(1)
+    end
+
+    it "when viewed previously, increments the job's views" do
+      published_job = build(:job, :published, views: 1)
+      expect(published_job.views).to eq(1)
+      published_job.increment_views
+      expect(published_job.views).to eq(2)
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -61,26 +61,28 @@ RSpec.describe Job do
     it "is true if the job title has changed" do
       job = create(:job)
       job.title = "New fancier title"
-      expect(job.name_changed?).to be_truthy
+      expect(job).to be_name_changed
     end
 
     it "is true if the job company has changed" do
       job = create(:job)
       job.company = "New fancier company name"
-      expect(job.name_changed?).to be_truthy
+      expect(job).to be_name_changed
     end
   end
 
   describe "#notify_if_published" do
     it "sends an email if the job was just published" do
       user = create(:user)
-      job = create(:job, :unpublished, user: user)
+      job = create(:job, :unpublished, user:)
       mail_double = double
       allow(mail_double).to receive(:deliver_now)
+      allow(SystemMailer).to receive(:job_post_published).with(user, job).and_return(mail_double)
 
-      expect(SystemMailer).to receive(:job_post_published).with(user, job).and_return(mail_double)
       job.published_at = 5.seconds.ago
       job.save!
+
+      expect(SystemMailer).to have_received(:job_post_published).with(user, job)
     end
   end
 

--- a/spec/requests/viewing_jobs_spec.rb
+++ b/spec/requests/viewing_jobs_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "ViewingJobs" do
   describe "GET /jobs" do
-    it "Displays active jobs" do
+    it "displays active jobs" do
       published_job = create(:job, :published, title: "A published job")
       not_active_job = create(:job, :no_longer_active, title: "Not active job")
 
@@ -11,6 +11,27 @@ RSpec.describe "ViewingJobs" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(published_job.title)
       expect(response.body).not_to include(not_active_job.title)
+    end
+  end
+
+  describe "GET /jobs/:id" do
+    it "displays the given job" do
+      published_job = create(:job, :published, title: "A published job")
+      not_active_job = create(:job, :no_longer_active, title: "Not active job")
+
+      get job_path(published_job)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(published_job.title)
+      expect(response.body).not_to include(not_active_job.title)
+      expect(response.body).to include(published_job.description.split("\n").first)
+    end
+
+    it "increments views for the given job if it's the first time they're seeing the post" do
+      published_job = create(:job, :published, title: "A published job")
+
+      expect { get job_path(published_job) }.to change(JobView, :count).by(1)
+      expect { get job_path(published_job) }.to change(JobView, :count).by(0)
     end
   end
 end


### PR DESCRIPTION
Years ago, the job board did not have a page refresh to view an individual job—instead, it was an accordion style expansion list _thing_. At some point, we therefore created an action for incrementing a "views" counter for jobs in the hopes of eventually getting some data on how often jobs are viewed. 

At some point we switched to a traditional request/response pattern, and the action for counting views sat unused. This PR removes the old action, and incorporates the code into the `JobsController#show` action instead. Of course, in an ideal world we'd do it asynchronously, but the overall performance should be negligible for now.