### PR TITLE
Move links for the calendar inline with the header

### DIFF
--- a/app/assets/stylesheets/content.scss
+++ b/app/assets/stylesheets/content.scss
@@ -57,5 +57,13 @@
     margin-top: 30px;
     display: flex;
     justify-content: space-around;
+
+    & > div {
+      padding: 1em 0;
+      display: flex;
+      margin-left: auto;
+      margin: 1em 0 1em auto;
+      gap: 1em;
+    }
   }
 }

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -37,12 +37,14 @@
   </div>
 </section>
 <section id="event-calendar">
-  <h2>Our calendar</h2>
-  <iframe src="//www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com&amp;color=%23AB8B00&amp;ctz=America%2FNew_York" style="border-width:0 " width="710" height="400" frameborder="0" scrolling="no"></iframe>
   <div class="calendar-links">
-    <%= link_to 'Recommend event', 'https://docs.google.com/forms/d/e/1FAIpQLSdlfIqF42uU8iyoYyqKDFPEYRsNCOCFYpFJwMTvdVOkK3otSg/viewform?usp=sf_link' %>
-    <%= link_to 'Subscribe to calendar', 'webcal://calendar.google.com/calendar/ical/ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com/public/basic.ics' %>
+    <h2>Our calendar</h2>
+    <div>
+      <%= link_to 'Recommend event', 'https://docs.google.com/forms/d/e/1FAIpQLSdlfIqF42uU8iyoYyqKDFPEYRsNCOCFYpFJwMTvdVOkK3otSg/viewform?usp=sf_link' %>
+      <%= link_to 'Subscribe to calendar', 'webcal://calendar.google.com/calendar/ical/ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com/public/basic.ics' %>
+    </div>
   </div>
+  <iframe src="//www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=ig7e0j6v8ub9q6kga256n77048%40group.calendar.google.com&amp;color=%23AB8B00&amp;ctz=America%2FNew_York" style="border-width:0 " width="710" height="400" frameborder="0" scrolling="no"></iframe>
 </section>
 <section class="blm" data-section="announcement">
     <div class="container">


### PR DESCRIPTION
Per #13 . 

The links for doing things with the calendar are currently difficult to discover, as you can see below:

<img width="1462" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/60a6ca66-f073-41ca-9ed4-942cceef9500">

With this change, they are now located inline with the header, as you can see below:

<img width="1366" alt="image" src="https://github.com/indyhackers/indyhackers.org/assets/2425/f0cf2f5c-0f04-4c62-9505-b27ae38b5292">

Hopefully this small change will have a positive effect on submissions for calendar events.

I solved it through CSS, flexbox stuffs in particular. I am not an expert on flexbox, but I do have a decent amount of experience tinkering with such layouts. If anyone sees issues with it or improvements to be made, please reach out. 