### PR TITLE
channel notifications for job submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem "test-unit"
 
 gem "rack-cache"
 
+gem "httparty"
+
 group :development, :test do
   gem "foreman"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    psych (5.1.0)
+    psych (5.1.2)
       stringio
     public_suffix (5.0.4)
     puma (6.4.2)
@@ -252,7 +252,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rb-readline (0.5.5)
-    rdoc (6.5.0)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
     regexp_parser (2.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,9 @@ GEM
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     inline_svg (1.9.0)
@@ -175,6 +178,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.0)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -381,6 +385,7 @@ DEPENDENCIES
   faker
   foreman
   haml (~> 5.2.1)
+  httparty
   inline_svg
   jquery-rails
   json_pure

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -66,17 +66,17 @@ class Job < ActiveRecord::Base
   end
 
   def notify_created
-    return unless ENV['SLACK_WEBSITE_COMMITTEE_WEBHOOK'].present?
+    return if ENV["SLACK_WEBSITE_COMMITTEE_WEBHOOK"].blank?
 
     url = "https://www.indyhackers.org/admin/jobs"
-    message = "New job board submission: <#{url}|#{self.title} at #{self.company}>"
+    message = "New job board submission: <#{url}|#{title} at #{company}>"
 
     HTTParty.post(
-      ENV['SLACK_WEBSITE_COMMITTEE_WEBHOOK'],
+      ENV["SLACK_WEBSITE_COMMITTEE_WEBHOOK"],
       body: {
         text: message
       }.to_json,
-      headers: { 'Content-Type' => 'application/json' }
+      headers: { "Content-Type" => "application/json" }
     )
   end
 


### PR DESCRIPTION
Sends a notification to #website-committee when new jobs are submitted

I've added the required configuration variable `SLACK_WEBSITE_COMMITTEE_WEBHOOK` to heroku