### PR TITLE
Change newsletter to buttondown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,8 +270,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
 
     %title= yield(:title).blank? ? "IndyHackers - Events and Jobs for Tech Folks in Indianapolis" : "#{yield(:title)} - IndyHackers"
 
-    %meta{:content => 'Miles Z. Sterrett', :name => "author"}/
+    %meta{:content => 'IndyHackers', :name => "author"}/
     - if yield(:description).blank?
       %meta{:content => "Bringing together hackers in Indiana", :name => "Description"}/
     - else
@@ -18,7 +18,7 @@
     = favicon_link_tag "/favicon.png"
     = yield(:head)
 
-  %body{class: "#{request[:controller].split('/').join(' ')} #{request[:action]}"}
+  %body{class: "#{params[:controller].split('/').join(' ')} #{params[:action]}"}
     = admin_header
     .main.main-body.container
       .header.navbar

--- a/app/views/newsletters/index.html.haml
+++ b/app/views/newsletters/index.html.haml
@@ -4,10 +4,10 @@
   %h1 Hacks &amp;&amp; Happenings
   %p
     :markdown
-      Indy Hackers is proud to present **Hacks && Happenings**, a quarterly collection of projects and blog posts by local developers and special developer-centric events delivered straight to your inbox!
-      You can [subscribe](http://indyhackers.us6.list-manage.com/subscribe?u=244b5370d41b5cf4146ec517c&id=b51f983563) now or [view the past issues](/newsletter/archive).
+      Indy Hackers is proud to present **Hacks && Happenings**, an every so often (we try for every other week!) collection of projects and blog posts by local developers and special developer-centric events delivered straight to your inbox!
+  
+  <iframe scrolling="no" style="width:100%!important;height:220px;border:1px #ccc solid !important" src="https://buttondown.email/indyhackers?as_embed=true"></iframe><br /><br />
 
-  %p Below you'll find archived versions of all of our newsletter's editions. Enjoy!
-  :css
-    .campaign {line-height: 125%; margin: 5px;}
-  <script language="javascript" src="//us6.campaign-archive1.com/generate-js/?u=244b5370d41b5cf4146ec517c&fid=2541&show=24" type="text/javascript"></script>
+  %p
+    :markdown
+      Archives are available [here](https://buttondown.email/indyhackers/archive/) and older archives are available [here](https://www.indyhackers.org/newsletter/archive).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   get 'hackies' => 'site#hackies'
 
-  get '/newsletter/subscribe' => redirect('http://eepurl.com/sMpJj')
+  get '/newsletter/subscribe' => redirect('https://buttondown.email/indyhackers')
   get '/newsletter' => 'newsletters#index'
   get '/newsletter/archive' => 'newsletters#index'
 

--- a/spec/requests/newsletters_controller_spec.rb
+++ b/spec/requests/newsletters_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe NewslettersController do
     it "redirects the user" do
       get "/newsletter/subscribe"
 
-      expect(response).to redirect_to("http://eepurl.com/sMpJj")
+      expect(response).to redirect_to("https://buttondown.email/indyhackers")
     end
   end
 end


### PR DESCRIPTION
Have imported all the current subscribers. This changes the in-app sign up to the new buttondown account, but preserves the existing archive functionality for the old mailchimp stuff.

Can be talked out of that.