### PR TITLE
Adds new archive-specific page

### DIFF
--- a/app/controllers/newsletters_controller.rb
+++ b/app/controllers/newsletters_controller.rb
@@ -1,3 +1,5 @@
 class NewslettersController < ApplicationController
   def index; end
+
+  def archive; end
 end

--- a/app/views/newsletters/archive.html.haml
+++ b/app/views/newsletters/archive.html.haml
@@ -1,0 +1,7 @@
+%h1 Mailchimp Archives
+
+%p
+  Below you'll find archived versions of our newsletter's editions from our time on Mailchimp. Enjoy!
+  :css
+    .campaign {line-height: 125%; margin: 5px;}
+  <script language="javascript" src="//us6.campaign-archive1.com/generate-js/?u=244b5370d41b5cf4146ec517c&fid=2541&show=24" type="text/javascript"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   get '/newsletter/subscribe' => redirect('https://buttondown.email/indyhackers')
   get '/newsletter' => 'newsletters#index'
-  get '/newsletter/archive' => 'newsletters#index'
+  get '/newsletter/archive' => 'newsletters#archive'
 
   resources :redirects, only: [:show], constraints: { id: /[a-z0-9_]+/i }, path: "r"
 


### PR DESCRIPTION
So, before, both the index and the archive went to the same view. This makes a new view that's just the old Mailchimp archive list.