### PR TITLE
change admin notifications email delivery to website committee

### DIFF
--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -1,13 +1,13 @@
 class SystemMailer < ActionMailer::Base
-  default from: "alfred@indyhackers.org"
-  default to: "miles@indyhackers.org"
+  default from: "hacks@indyhackers.org"
+  default to: "hacks@indyhackers.org"
 
   def job_post_request(job_post_request, job)
     @job_post_request = job_post_request
     @job = job
     mail(
       subject: "[IndyHackers Jobs] #{@job_post_request.title}",
-      from: %("#{@job_post_request.name}" <alfred@indyhackers.org>),
+      from: %("#{@job_post_request.name}" <hacks@indyhackers.org>),
       reply_to: @job_post_request.email
     )
   end
@@ -15,11 +15,11 @@ class SystemMailer < ActionMailer::Base
   def job_post_published(user, job)
     @user = user
     @job = job
-    send_to = @user.present? ? [@user.email, "miles@indyhackers.org"] : "miles@indyhackers.org"
+    send_to = @user.present? ? [@user.email, "hacks@indyhackers.org"] : "hacks@indyhackers.org"
     mail(
       subject: "[IndyHackers Jobs] Published! #{@job.title}",
-      from: %("IndyHackers" <alfred@indyhackers.org>),
-      reply_to: "miles@indyhackers.org",
+      from: %("IndyHackers" <hacks@indyhackers.org>),
+      reply_to: "hacks@indyhackers.org",
       to: send_to
     )
   end


### PR DESCRIPTION
Changes admin sends (mostly just job board notifications right now) to go to website committee (hacks@indyhackers.org).  We could send this to the whole board but I figured not everyone wants to see them.